### PR TITLE
Fix replication error in all_gather DCN test

### DIFF
--- a/src/benchmark_collectives.py
+++ b/src/benchmark_collectives.py
@@ -346,7 +346,11 @@ def all_gather_benchmark(
     if dcn_size > 1:
 
         @partial(
-            shard_map, mesh=mesh, in_specs=P("dcn", None), out_specs=P(None, None)
+            shard_map,
+            mesh=mesh,
+            in_specs=P("dcn", None),
+            out_specs=P(None, None),
+            check_rep=False,
         )
         def f(x):
             return jax.lax.all_gather(x, "dcn", tiled=True)


### PR DESCRIPTION
The `all_gather` benchmark for the DCN network path was failing with a replication check error. JAX's static analyzer cannot automatically prove that the output of `jax.lax.all_gather` is fully replicated when using optimizations like `tiled=True`.

This caused `shard_map` to raise an error because it couldn't verify that the operation's output matched the declared `out_specs=P(None, None)`.

This change adds the `check_rep=False` flag to the `shard_map` decorator, instructing it to trust the provided output specification and bypass the static check. This is the standard approach for resolving such errors and aligns the DCN benchmark with the existing ICI benchmark, which already uses this flag.