### PR TITLE
Extract latency from TPU trace for collective microbenchmarks

### DIFF
--- a/src/run_benchmark.py
+++ b/src/run_benchmark.py
@@ -346,7 +346,7 @@ def run_single_benchmark(benchmark_config: Dict[str, Any]):
         test_name = f"t_{benchmark_name}_" + "".join(
             random.choices(string.ascii_uppercase + string.digits, k=10)
         )
-        write_to_csv(f"{csv_path}/{test_name}.csv", calculate_metrics_results)
+        write_to_csv(f"{csv_path}/{test_name}.tsv", calculate_metrics_results)
 
 
 def main(config_path: str, multithreaded: bool):
@@ -455,7 +455,7 @@ def run_benchmark_multithreaded(benchmark_config):
             calculate_metrics_results.append({"metadata": metadata, "metrics": metrics})
 
     if csv_path:
-        write_to_csv(f"{csv_path}/{test_name}.csv", calculate_metrics_results)
+        write_to_csv(f"{csv_path}/{test_name}.tsv", calculate_metrics_results)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is a workaround to extract the latency from trace on TPU for collectives, and should be reverted or refactored in future.

The detailed changes include:
- Add a dictionary `TARGET_TASK_NAME_COLLECTIVES_MAP` in `src/benchmark_utils.py` to map a collective to its corresponding operation on TPU devices.
- Add a function `get_metrics_from_trace_tpu ` to extract the execution time of collective operation on TPU.