### PR TITLE
Extract time from tpu trace

### DIFF
--- a/src/benchmark_utils.py
+++ b/src/benchmark_utils.py
@@ -72,8 +72,11 @@ def get_metrics_from_trace(trace: dict[str, Any], task: str) -> list[float]:
     # Check if the given task name is a collective with corresponding TPU opertion.
     # This is a workaround and should be reverted or refactored in future.
     if task in TARGET_TASK_NAME_COLLECTIVES_MAP:
-        task = TARGET_TASK_NAME_COLLECTIVES_MAP[task]
-        return get_metrics_from_trace_tpu(trace, task)
+        try:
+            task = TARGET_TASK_NAME_COLLECTIVES_MAP[task]
+            return get_metrics_from_trace_tpu(trace, task)
+        except:
+            return [-1.]
     event_matcher = re.compile(task)
     
     if "traceEvents" not in trace:

--- a/src/run_benchmark.py
+++ b/src/run_benchmark.py
@@ -455,7 +455,7 @@ def run_benchmark_multithreaded(benchmark_config):
             calculate_metrics_results.append({"metadata": metadata, "metrics": metrics})
 
     if csv_path:
-        write_to_csv(f"{csv_path}/{test_name}.csv", calculate_metrics_results)
+        write_to_csv(f"{csv_path}/{test_name}.tsv", calculate_metrics_results)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR add a function `get_metrics_from_trace_tpu`, and enable JAX collectives functions to extract time from its main HLO.