### PR TITLE
Fix num_runs loop for DCN collective tests

### DIFF
--- a/src/benchmark_collectives.py
+++ b/src/benchmark_collectives.py
@@ -86,15 +86,14 @@ def psum_benchmark(
             matrix, jax.sharding.NamedSharding(mesh, P("dcn", None))
         )
         jitted_op = jax.jit(f)
-        for _ in range(num_runs):
-            dcn_average_time_ms_list = simple_timeit(
-                jitted_op,
-                sharded_matrix,
-                matrix_dim=matrix_dim,
-                tries=num_runs,
-                task="psum_dcn_op",
-                trace_dir=trace_dir,
-            )
+        dcn_average_time_ms_list = simple_timeit(
+            jitted_op,
+            sharded_matrix,
+            matrix_dim=matrix_dim,
+            tries=num_runs,
+            task="psum_dcn_op",
+            trace_dir=trace_dir,
+        )
 
     # ICI benchmark
     if ici_size > 1:
@@ -221,16 +220,14 @@ def psum_scatter_benchmark(
             matrix, jax.sharding.NamedSharding(mesh, P("dcn", None))
         )
         jitted_op = jax.jit(f)
-
-        for _ in range(num_runs):
-            dcn_average_time_ms_list = simple_timeit(
-                jitted_op,
-                sharded_matrix,
-                matrix_dim=matrix_dim,
-                tries=num_runs,
-                task="psum_scatter_dcn_op",
-                trace_dir=trace_dir,
-            )
+        dcn_average_time_ms_list = simple_timeit(
+            jitted_op,
+            sharded_matrix,
+            matrix_dim=matrix_dim,
+            tries=num_runs,
+            task="psum_scatter_dcn_op",
+            trace_dir=trace_dir,
+        )
 
     # ICI benchmark
     if ici_size > 1:
@@ -363,16 +360,14 @@ def all_gather_benchmark(
             matrix, jax.sharding.NamedSharding(mesh, P("dcn", None))
         )
         jitted_op = jax.jit(f)
-
-        for _ in range(num_runs):
-            dcn_average_time_ms_list = simple_timeit(
-                jitted_op,
-                sharded_matrix,
-                matrix_dim=matrix_dim,
-                tries=num_runs,
-                task="all_gather_dcn_op",
-                trace_dir=trace_dir,
-            )
+        dcn_average_time_ms_list = simple_timeit(
+            jitted_op,
+            sharded_matrix,
+            matrix_dim=matrix_dim,
+            tries=num_runs,
+            task="all_gather_dcn_op",
+            trace_dir=trace_dir,
+        )
 
     # ICI benchmark
     if ici_size > 1:
@@ -507,16 +502,14 @@ def ppermute_benchmark(
             matrix, jax.sharding.NamedSharding(mesh, P("dcn", None))
         )
         jitted_op = jax.jit(f)
-
-        for _ in range(num_runs):
-            dcn_average_time_ms_list = simple_timeit(
-                jitted_op,
-                sharded_matrix,
-                matrix_dim=matrix_dim,
-                tries=num_runs,
-                task="ppermute_dcn_op",
-                trace_dir=trace_dir,
-            )
+        dcn_average_time_ms_list = simple_timeit(
+            jitted_op,
+            sharded_matrix,
+            matrix_dim=matrix_dim,
+            tries=num_runs,
+            task="ppermute_dcn_op",
+            trace_dir=trace_dir,
+        )
 
     # ICI benchmark
     if ici_size > 1:


### PR DESCRIPTION
`simple_timeit` function already loops `num_runs` times internally, for DCN there is `for-loop` wrapper around `simple_timeit` which makes the total loops `num_runs` * `num_runs` which is inconsistent with what user is expecting

This PR fixes this issue.

@hylin2002 @chishuen 