### PR TITLE
Add Warmup Loop for JIT ops

### DIFF
--- a/configs/sample_benchmark_collectives.yaml
+++ b/configs/sample_benchmark_collectives.yaml
@@ -2,23 +2,27 @@ benchmarks:
 - benchmark_name: ppermute
   benchmark_sweep_params:
   - {matrix_dim_range: {start: 1024, end: 20000, increase_by: 1024}, dtype: "bfloat16", dcn_size_range: 1, ici_size_range: 4}
+  warmup_tries: 10
   trace_dir: "/tmp/microbenchmarks/collectives"
   csv_path: "/tmp/microbenchmarks/collectives"
   xla_dump_dir: "/tmp/microbenchmarks/collective/hlo_graphs"
 - benchmark_name: all_gather
   benchmark_sweep_params:
   - {matrix_dim_range: {start: 1024, end: 20000, increase_by: 1024}, dtype: "bfloat16", dcn_size_range: 1, ici_size_range: 4}
+  warmup_tries: 10
   trace_dir: "/tmp/microbenchmarks/collectives"
   csv_path: "/tmp/microbenchmarks/collectives"
   xla_dump_dir: "/tmp/microbenchmarks/collective/hlo_graphs"
 - benchmark_name: psum
   benchmark_sweep_params:
   - {matrix_dim_range: {start: 1024, end: 20000, increase_by: 1024}, dtype: "bfloat16", dcn_size_range: 1, ici_size_range: 4}
+  warmup_tries: 10
   trace_dir: "/tmp/microbenchmarks/collectives"
   csv_path: "/tmp/microbenchmarks/collectives"
   xla_dump_dir: "/tmp/microbenchmarks/collective/hlo_graphs"
 - benchmark_name: psum_scatter
   benchmark_sweep_params:
   - {matrix_dim_range: {start: 1024, end: 20000, increase_by: 1024}, dtype: "bfloat16", dcn_size_range: 1, ici_size_range: 4}
+  warmup_tries: 10
   trace_dir: "/tmp/microbenchmarks/collectives"
   csv_path: "/tmp/microbenchmarks/collectives"

--- a/src/benchmark_collectives.py
+++ b/src/benchmark_collectives.py
@@ -86,15 +86,14 @@ def psum_benchmark(
             matrix, jax.sharding.NamedSharding(mesh, P("dcn", None))
         )
         jitted_op = jax.jit(f)
-        for _ in range(num_runs):
-            dcn_average_time_ms_list = simple_timeit(
-                jitted_op,
-                sharded_matrix,
-                matrix_dim=matrix_dim,
-                tries=num_runs,
-                task="psum_dcn_op",
-                trace_dir=trace_dir,
-            )
+        dcn_average_time_ms_list = simple_timeit(
+            jitted_op,
+            sharded_matrix,
+            matrix_dim=matrix_dim,
+            tries=num_runs,
+            task="psum_dcn_op",
+            trace_dir=trace_dir,
+        )
 
     # ICI benchmark
     if ici_size > 1:
@@ -221,16 +220,14 @@ def psum_scatter_benchmark(
             matrix, jax.sharding.NamedSharding(mesh, P("dcn", None))
         )
         jitted_op = jax.jit(f)
-
-        for _ in range(num_runs):
-            dcn_average_time_ms_list = simple_timeit(
-                jitted_op,
-                sharded_matrix,
-                matrix_dim=matrix_dim,
-                tries=num_runs,
-                task="psum_scatter_dcn_op",
-                trace_dir=trace_dir,
-            )
+        dcn_average_time_ms_list = simple_timeit(
+            jitted_op,
+            sharded_matrix,
+            matrix_dim=matrix_dim,
+            tries=num_runs,
+            task="psum_scatter_dcn_op",
+            trace_dir=trace_dir,
+        )
 
     # ICI benchmark
     if ici_size > 1:
@@ -363,16 +360,14 @@ def all_gather_benchmark(
             matrix, jax.sharding.NamedSharding(mesh, P("dcn", None))
         )
         jitted_op = jax.jit(f)
-
-        for _ in range(num_runs):
-            dcn_average_time_ms_list = simple_timeit(
-                jitted_op,
-                sharded_matrix,
-                matrix_dim=matrix_dim,
-                tries=num_runs,
-                task="all_gather_dcn_op",
-                trace_dir=trace_dir,
-            )
+        dcn_average_time_ms_list = simple_timeit(
+            jitted_op,
+            sharded_matrix,
+            matrix_dim=matrix_dim,
+            tries=num_runs,
+            task="all_gather_dcn_op",
+            trace_dir=trace_dir,
+        )
 
     # ICI benchmark
     if ici_size > 1:
@@ -507,16 +502,14 @@ def ppermute_benchmark(
             matrix, jax.sharding.NamedSharding(mesh, P("dcn", None))
         )
         jitted_op = jax.jit(f)
-
-        for _ in range(num_runs):
-            dcn_average_time_ms_list = simple_timeit(
-                jitted_op,
-                sharded_matrix,
-                matrix_dim=matrix_dim,
-                tries=num_runs,
-                task="ppermute_dcn_op",
-                trace_dir=trace_dir,
-            )
+        dcn_average_time_ms_list = simple_timeit(
+            jitted_op,
+            sharded_matrix,
+            matrix_dim=matrix_dim,
+            tries=num_runs,
+            task="ppermute_dcn_op",
+            trace_dir=trace_dir,
+        )
 
     # ICI benchmark
     if ici_size > 1:

--- a/src/benchmark_collectives.py
+++ b/src/benchmark_collectives.py
@@ -57,6 +57,7 @@ def psum_benchmark(
     ici_size: int,
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the psum collective operation.
 
@@ -90,6 +91,7 @@ def psum_benchmark(
             jitted_op,
             sharded_matrix,
             matrix_dim=matrix_dim,
+            warmup_tries=warmup_tries,
             tries=num_runs,
             task="psum_dcn_op",
             trace_dir=trace_dir,
@@ -110,6 +112,7 @@ def psum_benchmark(
             jitted_op,
             sharded_matrix,
             matrix_dim=matrix_dim,
+            warmup_tries=warmup_tries,
             tries=num_runs,
             task="psum_ici_op",
             trace_dir=trace_dir,
@@ -189,6 +192,7 @@ def psum_scatter_benchmark(
     ici_size: int,
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the psum_scatter collective operation.
 
@@ -224,6 +228,7 @@ def psum_scatter_benchmark(
             jitted_op,
             sharded_matrix,
             matrix_dim=matrix_dim,
+            warmup_tries=warmup_tries,
             tries=num_runs,
             task="psum_scatter_dcn_op",
             trace_dir=trace_dir,
@@ -244,6 +249,7 @@ def psum_scatter_benchmark(
             jitted_op,
             sharded_matrix,
             matrix_dim=matrix_dim,
+            warmup_tries=warmup_tries,
             tries=num_runs,
             task="psum_scatter_ici_op",
             trace_dir=trace_dir,
@@ -322,6 +328,7 @@ def all_gather_benchmark(
     dtype: jnp.dtype,
     dcn_size: int,
     ici_size: int,
+    warmup_tries: int = 10,
     num_runs: int = 1,
     trace_dir: str = None,
 ) -> Dict[str, Any]:
@@ -364,6 +371,7 @@ def all_gather_benchmark(
             jitted_op,
             sharded_matrix,
             matrix_dim=matrix_dim,
+            warmup_tries=warmup_tries,
             tries=num_runs,
             task="all_gather_dcn_op",
             trace_dir=trace_dir,
@@ -390,6 +398,7 @@ def all_gather_benchmark(
             jitted_op,
             sharded_matrix,
             matrix_dim=matrix_dim,
+            warmup_tries=warmup_tries,
             tries=num_runs,
             task="all_gather_ici_op",
             trace_dir=trace_dir,
@@ -469,6 +478,7 @@ def ppermute_benchmark(
     ici_size: int,
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the ppermute collective operation.
 
@@ -506,6 +516,7 @@ def ppermute_benchmark(
             jitted_op,
             sharded_matrix,
             matrix_dim=matrix_dim,
+            warmup_tries=warmup_tries,
             tries=num_runs,
             task="ppermute_dcn_op",
             trace_dir=trace_dir,
@@ -527,6 +538,7 @@ def ppermute_benchmark(
             jitted_op,
             sharded_matrix,
             matrix_dim=matrix_dim,
+            warmup_tries=warmup_tries,
             tries=num_runs,
             task="ppermute_ici_op",
             trace_dir=trace_dir,
@@ -598,6 +610,7 @@ def all_to_all_benchmark(
     ici_size: int,
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the all_to_all collective operation.
 
@@ -634,6 +647,7 @@ def all_to_all_benchmark(
             jitted_op,
             sharded_matrix,
             matrix_dim=matrix_dim,
+            warmup_tries=warmup_tries,
             tries=num_runs,
             task="all_to_all_dcn_op",
             trace_dir=trace_dir,
@@ -660,6 +674,7 @@ def all_to_all_benchmark(
             jitted_op,
             sharded_matrix,
             matrix_dim=matrix_dim,
+            warmup_tries=warmup_tries,
             tries=num_runs,
             task="all_to_all_ici_op",
             trace_dir=trace_dir,

--- a/src/run_benchmark.py
+++ b/src/run_benchmark.py
@@ -279,6 +279,8 @@ def run_single_benchmark(benchmark_config: Dict[str, Any]):
     trace_dir = benchmark_config.get("trace_dir")
     xlml_metrics_dir = benchmark_config.get("xlml_metrics_dir")
     xla_dump_dir = benchmark_config.get("xla_dump_dir")
+    warmup_tries = benchmark_config.get("warmup_tries")
+    warmup_tries = warmup_tries if warmup_tries is not None else 1000
 
     if not benchmark_name:
         raise ValueError("Each benchmark must have a 'benchmark_name'.")
@@ -299,7 +301,7 @@ def run_single_benchmark(benchmark_config: Dict[str, Any]):
         test_start_time = (
             datetime.datetime.now(tz=datetime.timezone.utc).isoformat() + "Z"
         )  # "Z" indicates UTC
-        benchmark_results = benchmark_func(**benchmark_param)
+        benchmark_results = benchmark_func(**benchmark_param, warmup_tries=warmup_tries)
         test_end_time = (
             datetime.datetime.now(tz=datetime.timezone.utc).isoformat() + "Z"
         )
@@ -400,6 +402,8 @@ def run_benchmark_multithreaded(benchmark_config):
     csv_path = benchmark_config.get("csv_path")
     if not benchmark_name:
         raise ValueError("Each benchmark must have a 'benchmark_name'.")
+    warmup_tries = benchmark_config.get("warmup_tries")
+    warmup_tries = warmup_tries if warmup_tries is not None else 1000
 
     # Get the benchmark function
     benchmark_func, calculate_metrics_func = get_benchmark_functions(benchmark_name)
@@ -427,7 +431,7 @@ def run_benchmark_multithreaded(benchmark_config):
     with ThreadPoolExecutor(max_workers=num_hosts) as executor:
         # Create a mapping of futures to their corresponding parameters
         future_to_param = {
-            executor.submit(benchmark_func, **benchmark_param): benchmark_param
+            executor.submit(benchmark_func, **benchmark_param, warmup_tries=warmup_tries): benchmark_param
             for benchmark_param in preprocessed_benchmark_params
         }
 


### PR DESCRIPTION
This PR introduces a change where instead of running a warmup operation once, we create warmup loop which can be configured by the user manually through the config file.

The reason is to ensure that TPU chip reaches a steady state before we start calculation for the actual operation, this will ensure that we get consistent results.

Ref: https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/commit/c3bef5aa33e132e2fdb33763c98aafec4bf1ba7a