### PR TITLE
Add warmup_tries param to every benchmark function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ gcloud compute ssh $TPU_NAME --zone=$ZONE
 
 Now that you have the VM environment set up, `git clone` the accelerator-microbenchmarks on the VM and install the dependencies:
 ```bash
-git clone https://github.com/qinyiyan/accelerator-microbenchmarks.git
+git clone https://github.com/AI-Hypercomputer/accelerator-microbenchmarks.git
 pip install -r requirements.txt
 ```
 

--- a/src/benchmark_attention.py
+++ b/src/benchmark_attention.py
@@ -83,6 +83,7 @@ def naive_attention_benchmark(
     scale: bool = False,
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Naive attention benchmark."""
 
@@ -120,6 +121,7 @@ def naive_attention_benchmark(
         v,
         causal,
         scale,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="naive_attention",
         trace_dir=trace_dir,
@@ -152,6 +154,7 @@ def pallas_flash_attention_benchmark(
     causal: bool = True,
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the Pallas flash attention kernel."""
 
@@ -174,6 +177,7 @@ def pallas_flash_attention_benchmark(
         k,
         v,
         causal,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="pallas_flash_attention",
         trace_dir=trace_dir,
@@ -205,6 +209,7 @@ def splash_attention_benchmark(
     causal: bool = True,
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the Splash attention kernel."""
 
@@ -257,6 +262,7 @@ def splash_attention_benchmark(
         k,
         v,
         causal,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="splash_attention",
         trace_dir=trace_dir,
@@ -287,6 +293,7 @@ def flax_nnx_attention_benchmark(
     num_heads: int,
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the Flax nnx attention."""
 
@@ -313,6 +320,7 @@ def flax_nnx_attention_benchmark(
         q,
         k,
         v,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="flax_attention",
         trace_dir=trace_dir,
@@ -342,6 +350,7 @@ def flax_linen_attention_benchmark(
     num_heads: int,
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the Flax linen attention."""
 
@@ -367,6 +376,7 @@ def flax_linen_attention_benchmark(
         q,
         k,
         v,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="flax_attention",
         trace_dir=trace_dir,
@@ -397,6 +407,7 @@ def keras_attention_benchmark(
     causal: bool = False,
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the Flax linen attention."""
 
@@ -432,6 +443,7 @@ def keras_attention_benchmark(
         k,
         v,
         causal,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="keras_attention",
         trace_dir=trace_dir,

--- a/src/benchmark_convolution.py
+++ b/src/benchmark_convolution.py
@@ -25,6 +25,7 @@ def convolve_common(
     task_name: str,
     num_runs: int,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """A helper function to run the convolution benchmark.
 
@@ -64,6 +65,7 @@ def convolve_common(
         x,
         kernel,
         padding_mode,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task=task_name,
         trace_dir=trace_dir,
@@ -129,6 +131,7 @@ def numpy_convolve(
     padding_mode: str = "same",
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> float:
     """Benchmarks 1D convolution with jax.numpy.convolve."""
 
@@ -145,6 +148,7 @@ def numpy_convolve(
         "numpy_convolve",
         num_runs=num_runs,
         trace_dir=trace_dir,
+        warmup_tries=warmup_tries,
     )
 
 
@@ -174,6 +178,7 @@ def scipy_signal_convolve(
     padding_mode: str = "same",
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> float:
     """Benchmarks N-dimensional convolution using jax.scipy.signal.convolve."""
 
@@ -190,6 +195,7 @@ def scipy_signal_convolve(
         "scipy_signal_convolve",
         num_runs=num_runs,
         trace_dir=trace_dir,
+        warmup_tries=warmup_tries,
     )
 
 
@@ -219,6 +225,7 @@ def scipy_signal_convolve2d(
     padding_mode: str = "same",
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> float:
     """Benchmarks 2D convolution using jax.scipy.signal.convolve2d."""
     input_shape = (input_size, input_size)
@@ -235,6 +242,7 @@ def scipy_signal_convolve2d(
         "scipy_signal_convolve2d",
         num_runs=num_runs,
         trace_dir=trace_dir,
+        warmup_tries=warmup_tries,
     )
 
 
@@ -272,6 +280,7 @@ def lax_conv_general_dilated(
     dimension_numbers: Tuple[str, str, str] = ("NHWC", "HWIO", "NHWC"),
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> float:
     """Benchmarks convolution with jax.lax.conv_general_dilated."""
 
@@ -312,6 +321,7 @@ def lax_conv_general_dilated(
         stride,
         dilation,
         padding_mode,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="lax_conv_general_dilated",
         trace_dir=trace_dir,

--- a/src/benchmark_hbm.py
+++ b/src/benchmark_hbm.py
@@ -26,6 +26,7 @@ def single_chip_hbm_copy(
     dtype: jnp.dtype,
     num_runs: int = 1,
     trace_dir: str = None,
+    warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks HBM with copy(read and write) on a single device."""
 
@@ -43,6 +44,7 @@ def single_chip_hbm_copy(
     time_ms_list = simple_timeit(
         jitted_f,
         a,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="single_chip_hbm_copy",
         trace_dir=trace_dir,

--- a/src/benchmark_matmul.py
+++ b/src/benchmark_matmul.py
@@ -67,7 +67,7 @@ def get_metrics_helper(
 
 
 def naive_matmul(
-    m: int, k: int, n: int, num_runs: int = 1, trace_dir: str = None
+    m: int, k: int, n: int, num_runs: int = 1, trace_dir: str = None, warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the jax.numpy.einsum."""
 
@@ -99,6 +99,7 @@ def naive_matmul(
         jit_sharded_f,
         lhs,
         rhs,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="naive_matmul",
         trace_dir=trace_dir,
@@ -154,7 +155,7 @@ def naive_matmul_calculate_metrics(
 
 
 def single_host_naive_matmul(
-    m: int, k: int, n: int, num_runs: int = 1, trace_dir: str = None
+    m: int, k: int, n: int, num_runs: int = 1, trace_dir: str = None, warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks matmul on a single device without any sharding."""
 
@@ -174,6 +175,7 @@ def single_host_naive_matmul(
         jitted_f,
         lhs,
         rhs,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="single_host_naive_matmul",
         trace_dir=trace_dir,
@@ -229,7 +231,7 @@ def single_host_naive_matmul_calculate_metrics(
 
 
 def collective_matmul_one_direction(
-    m: int, k: int, n: int, num_runs: int = 1, trace_dir: str = None
+    m: int, k: int, n: int, num_runs: int = 1, trace_dir: str = None, warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the collective matmul that does permute in one direction."""
 
@@ -287,6 +289,7 @@ def collective_matmul_one_direction(
         jit_sharded_f,
         lhs,
         rhs,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="collective_matmul_one_direction",
         trace_dir=trace_dir,
@@ -329,7 +332,7 @@ def collective_matmul_one_direction_calculate_metrics(
 
 
 def collective_matmul_two_directions(
-    m: int, k: int, n: int, num_runs: int = 1, trace_dir: str = None
+    m: int, k: int, n: int, num_runs: int = 1, trace_dir: str = None, warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the collective matmul that does permute in two directions."""
 
@@ -424,6 +427,7 @@ def collective_matmul_two_directions(
         jit_sharded_f,
         lhs,
         rhs,
+        warmup_tries=warmup_tries,
         tries=num_runs,
         task="collective_matmul_two_directions",
         trace_dir=trace_dir,
@@ -466,7 +470,7 @@ def collective_matmul_two_directions_calculate_metrics(
 
 
 def multilayer_collective_matmul(
-    m: int, k: int, n: int, num_runs: int = 1, trace_dir: str = None
+    m: int, k: int, n: int, num_runs: int = 1, trace_dir: str = None, warmup_tries: int = 10,
 ) -> Dict[str, Any]:
     """Benchmarks the multilayer collective matmul."""
 
@@ -506,6 +510,8 @@ def multilayer_collective_matmul(
         jit_sharded_f,
         activation,
         weights,
+        warmup_tries=warmup_tries,
+        tries=num_runs,
         task="collective_multilayer_matmul",
         trace_dir=trace_dir,
     )

--- a/src/benchmark_utils.py
+++ b/src/benchmark_utils.py
@@ -24,7 +24,7 @@ def simple_timeit(f, *args, matrix_dim=None, warmup_tries = 10, tries=10, task=N
     assert task is not None
 
     if trace_dir:
-        return timeit_from_trace(f, *args, matrix_dim=matrix_dim, tries=tries, task=task, trace_dir=trace_dir)
+        return timeit_from_trace(f, *args, matrix_dim=matrix_dim, warmup_tries=warmup_tries, tries=tries, task=task, trace_dir=trace_dir)
 
     # warmup loop
     print(f"Running warmup loop with {warmup_tries} tries...")


### PR DESCRIPTION
[PR](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/pull/30) caused errors in nightly runs of the benchmark test. This PR fixes the issue

- Add `warmup_tries` param to all other benchmark functions.
- Add `warmup_tries` param to `timeit_from_trace` function in `benchmark_utils.py` .

Bug: b/446192891

Tested with `python src/run_benchmark.py --config=configs/xlml_v6e_4_2slice.yaml` 

Logs: https://cloudlogging.app.goo.gl/o7e1YuzRniGowAmo6