### PR TITLE
add Tokamax Splash Attention benchmark

### DIFF
--- a/configs/sample_benchmark_attention.yaml
+++ b/configs/sample_benchmark_attention.yaml
@@ -57,3 +57,14 @@ benchmarks:
   trace_dir: "/tmp/microbenchmarks/attention"
   csv_path: "/tmp/microbenchmarks/attention"
   xlml_metrics_dir: "/tmp/microbenchmarks/attention"
+- benchmark_name: "tokamax_splash_attention"
+  benchmark_sweep_params:
+  - {batch_size_range: {start: 1, end: 8, multiplier: 2}, q_seq_len: 1024, kv_seq_len: 1024, q_heads: 8, kv_heads: 8, qk_head_dim: 128, v_head_dim: 128, mode_list: ["fwd", "bwd"], causal: true}
+  - {batch_size: 2, q_seq_len_range: {start: 512, end: 4096, multiplier: 2}, kv_seq_len_range: {start: 512, end: 4096, multiplier: 2}, q_heads: 8, kv_heads: 8, qk_head_dim: 128, v_head_dim: 128, mode: "fwd", causal_list: [true, false]}
+  - {batch_size: 2, q_seq_len: 1024, kv_seq_len: 1024, q_heads: 16, kv_heads_list: [1, 4, 16], qk_head_dim: 128, v_head_dim: 128, mode_list: ["fwd", "bwd"], causal: true}
+  - {batch_size: 2, q_seq_len: 1024, kv_seq_len: 1024, q_heads: 8, kv_heads: 8, qk_head_dim_list: [64, 128, 256], v_head_dim_list: [64, 128, 256], mode: "fwd", causal: true}
+  - {batch_size: 2, q_seq_len: 1024, kv_seq_len: 4096, q_heads: 8, kv_heads: 8, qk_head_dim: 128, v_head_dim: 128, mode_list: ["fwd", "bwd"], causal: false}
+  - {batch_size: 1, q_seq_len: 8192, kv_seq_len: 8192, q_heads: 16, kv_heads: 16, qk_head_dim: 256, v_head_dim: 256, mode: "combined", causal: true, num_samples: 1024}
+  trace_dir: "/tmp/microbenchmarks/attention"
+  csv_path: "/tmp/microbenchmarks/attention"
+  xlml_metrics_dir: "/tmp/microbenchmarks/attention"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ tensorboard-plugin-profile
 # Install tensorflow to avoid spurring "Can't import tensorflow.python.profiler.trace" error from jax.profiler.
 tensorflow
 qwix@git+https://github.com/google/qwix.git
+tokamax
+tune-jax

--- a/src/benchmark_attention.py
+++ b/src/benchmark_attention.py
@@ -19,7 +19,8 @@ library.
 # pylint: disable=g-importing-member,g-bad-import-order
 from functools import partial
 import os
-from typing import Any, Dict, Tuple
+from typing import Any, Callable, Dict, Tuple
+import dataclasses
 
 from benchmark_utils import simple_timeit, MetricsStatistics
 from flax import linen
@@ -28,6 +29,9 @@ import jax
 from jax.experimental.pallas.ops.tpu import flash_attention as pallas_flash_attention
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask
+from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_kernel as splash
+from tokamax._src.ops.experimental.tpu.splash_attention import splash_attention_mask as mask_lib
+import tune_jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -53,6 +57,25 @@ def generate_qkv(
     q = jax.random.normal(key_q, (batch, num_heads, seq_len, head_dim))
     k = jax.random.normal(key_k, (batch, num_heads, seq_len, head_dim))
     v = jax.random.normal(key_v, (batch, num_heads, seq_len, head_dim))
+    return q, k, v
+
+
+def generate_qkv_separate_dims(
+    batch_size: int,
+    q_seq_len: int,
+    kv_seq_len: int,
+    q_heads: int,
+    kv_heads: int,
+    qk_head_dim: int,
+    v_head_dim: int,
+    seed: int = 0
+) -> Tuple[jax.Array, jax.Array, jax.Array]:
+    """Generates QKV with potentially different shapes for Q, K, and V."""
+    key = jax.random.PRNGKey(seed)
+    key_q, key_k, key_v = jax.random.split(key, 3)
+    q = jax.random.normal(key_q, (batch_size, q_heads, q_seq_len, qk_head_dim))
+    k = jax.random.normal(key_k, (batch_size, kv_heads, kv_seq_len, qk_head_dim))
+    v = jax.random.normal(key_v, (batch_size, kv_heads, kv_seq_len, v_head_dim))
     return q, k, v
 
 
@@ -449,6 +472,237 @@ def keras_attention_benchmark_calculate_metrics(
     # pylint: disable=unused-argument
 ) -> Dict[str, Any]:
     """Gathers metrics for the keras attention benchmark."""
+    # Build dictionary of all the parameters in the function
+    params = locals().items()
+    return get_metrics_helper(params)
+
+
+def _pallas_call_hlo_pattern(mode: str, mqa: bool) -> str:
+    """Generates an HLO pattern regex for filtering Pallas calls."""
+    if mode not in ["fwd", "bwd", "combined"]:
+        raise ValueError(f"Invalid mode: {mode}, select either 'fwd' or 'bwd'.")
+    mha_or_mqa = "mqa" if mqa else "mha"
+    suffix = {"fwd": "fwd", "bwd": "dkv", "combined": ""}.get(mode, "")
+    return f"splash_{mha_or_mqa}_{suffix}"
+
+
+def _get_tokamax_benchmark_fn(
+    mask: mask_lib.Mask,
+    config: splash.SplashConfig, 
+    mode: str, 
+    mqa: bool
+) -> Callable:
+    """Gets the benchmark function for Tokamax Splash Attention."""
+    config = dataclasses.replace(config, use_base2_exp=True)
+    if mqa:
+        kernel = splash.make_splash_mqa_single_device(mask, config=config)
+
+        @jax.jit
+        def f(q, k, v):
+            q = q.reshape(q.shape[:-3] + (k.shape[-3], -1) + q.shape[-2:])
+            kernel_ = jax.vmap(kernel, in_axes=(0, 0, 0))  # batch vmap
+            kernel_ = jax.vmap(kernel_, in_axes=(0, 0, 0))  # mqa vmap
+            return kernel_(q, k, v)
+    else:
+        kernel = splash.make_splash_mha_single_device(mask, config=config)
+        f = jax.jit(jax.vmap(kernel, in_axes=(0, 0, 0)))
+
+    if mode == "fwd":
+        return f
+    if mode == "bwd":
+        return jax.grad(lambda q, k, v: f(q, k, v).mean(), argnums=(0, 1, 2))
+    raise ValueError(f"Invalid mode: {mode}")
+
+
+def tokamax_splash_attention_benchmark(
+    batch_size: int,
+    q_seq_len: int,
+    kv_seq_len: int,
+    q_heads: int,
+    kv_heads: int,
+    qk_head_dim: int,
+    v_head_dim: int,
+    mode: str = "fwd",  # One of ('fwd', 'bwd', 'combined')
+    causal: bool = True,
+    num_samples: int = 256,
+    tune_pallas_only: bool = True,
+    num_runs: int = 1,
+    trace_dir: str = None,
+    warmup_tries: int = 10,
+) -> Dict[str, Any]:
+  """Benchmarks the Tokamax Splash attention kernel."""
+
+  if tune_pallas_only:
+    event_filter_regex = _pallas_call_hlo_pattern(mode, q_heads != kv_heads)
+  else:
+    event_filter_regex = None
+
+  hyperparams_override = {}
+  if mode == "bwd":
+    # Don't tune fwd only hyperparams
+    hyperparams_override = dict(
+        block_q=min(512, q_seq_len),
+        block_kv=min(1024, kv_seq_len),
+        block_kv_compute=min(512, kv_seq_len),
+    )
+  elif mode == "combined":
+    mode = "bwd"
+
+  # Generate QKV.
+  q, k, v = generate_qkv_separate_dims(
+      batch_size,
+      q_seq_len,
+      kv_seq_len,
+      q_heads,
+      kv_heads,
+      qk_head_dim,
+      v_head_dim,
+  )
+
+  # Attention mask
+  mask = mask_lib.FullMask(_shape=(q_seq_len, kv_seq_len))
+  if causal:
+    # Pick offset for causal masks for a "representative" slice of the causal
+    offset = (
+        0
+        if q.shape[-2] == v.shape[-2]
+        else (v.shape[-2] // 2 - q.shape[-2] // 2)
+    )
+    mask = mask_lib.CausalMask(shape=(q_seq_len, kv_seq_len), offset=offset)
+
+  def attention_fn(
+      q: jax.Array,
+      k: jax.Array,
+      v: jax.Array,
+      block_q: int,
+      block_kv: int,
+      block_kv_compute: int,
+      block_q_dkv: int | None,
+      block_kv_dkv: int | None,
+      block_kv_dkv_compute: int | None,
+      block_q_dq: int | None,
+      block_kv_dq: int | None,
+      q_layout: splash.QKVLayout,
+      k_layout: splash.QKVLayout,
+      v_layout: splash.QKVLayout,
+      mask: mask_lib.Mask,
+      mode: str,
+      mqa: bool,
+  ):
+    config = splash.SplashConfig(
+        block_q=block_q,
+        block_kv=block_kv,
+        block_kv_compute=block_kv_compute,
+        block_q_dkv=block_q_dkv,
+        block_kv_dkv=block_kv_dkv,
+        block_kv_dkv_compute=block_kv_dkv_compute,
+        block_q_dq=block_q_dq,
+        block_kv_dq=block_kv_dq,
+        q_layout=q_layout,
+        k_layout=k_layout,
+        v_layout=v_layout,
+    )
+
+    f = _get_tokamax_benchmark_fn(mask, config, mode, mqa=mqa)
+    return f(q, k, v)
+
+  attention_fn = partial(
+      attention_fn,
+      mask=mask,
+      mode=mode,
+      mqa=q_heads != kv_heads,  # Determine if it's Multi-Query Attention
+  )
+
+  # Define the search space for tokamax splash attention hyperparameters.
+  tiles = [256, 512, 1024, 2048]
+  layouts = [splash.QKVLayout.HEAD_DIM_MINOR, splash.QKVLayout.SEQ_MINOR]
+  hyperparams = {
+      "block_q": tiles,
+      "block_kv": tiles,
+      "block_kv_compute": tiles,
+      "block_q_dkv": [None],
+      "block_kv_dkv": [None],
+      "block_kv_dkv_compute": [None],
+      "block_q_dq": [None],
+      "block_kv_dq": [None],
+      "q_layout": layouts,
+      "k_layout": layouts,
+      "v_layout": layouts,
+  }
+
+  if mode == "bwd":
+    # If mode is backward, enable tuning for dKV-related block sizes.
+    # These parameters are only used during the backward pass.
+    hyperparams["block_q_dkv"] = tiles
+    hyperparams["block_kv_dkv"] = tiles
+    hyperparams["block_kv_dkv_compute"] = tiles
+
+  # Incorporate any potentially previously tuned hyperparameters
+  hyperparams_override = hyperparams_override or {}
+  hyperparams = dict(hyperparams, **hyperparams_override)
+
+  # Prepare the attention function for tuning.
+  tune_jax.CONFIG.allow_fallback_timing = False
+  splash_fn = jax.jit(
+      attention_fn,
+      static_argnames=(
+          "block_q",
+          "block_kv",
+          "block_kv_compute",
+          "block_q_dkv",
+          "block_kv_dkv",
+          "block_kv_dkv_compute",
+          "block_q_dq",
+          "block_kv_dq",
+          "q_layout",
+          "k_layout",
+          "v_layout",
+      ),
+  )
+
+  # Tune the hyperparameters with tune_jax
+  tuned_splash = tune_jax.tune(
+      splash_fn,
+      hyperparams=hyperparams,
+      event_filter_regex=event_filter_regex,
+      sample_num=num_samples,
+  )
+
+  # Run once
+  output = tuned_splash(q, k, v)
+  jax.block_until_ready(output)
+
+  # Run benchmark
+  time_ms_list = simple_timeit(
+      tuned_splash,
+      q,
+      k,
+      v,
+      warmup_tries=warmup_tries,
+      tries=num_runs,
+      task="flax_attention",
+      trace_dir=trace_dir,
+  )
+  return {"time_ms_list": time_ms_list, "output": output}
+
+
+def tokamax_splash_attention_benchmark_calculate_metrics(
+    # pylint: disable=unused-argument
+    batch_size: int,
+    q_seq_len: int,
+    kv_seq_len: int,
+    q_heads: int,
+    kv_heads: int,
+    qk_head_dim: int,
+    v_head_dim: int,
+    mode: str,
+    causal: bool,
+    num_samples: int,
+    tune_pallas_only: bool,
+    time_ms_list: list[float],
+    # pylint: disable=unused-argument
+) -> Dict[str, Any]:
+    """Gathers metrics for the tokamax splash attention benchmark."""
     # Build dictionary of all the parameters in the function
     params = locals().items()
     return get_metrics_helper(params)

--- a/src/run_benchmark.py
+++ b/src/run_benchmark.py
@@ -56,6 +56,7 @@ ATTENTION_BENCHMARK_MAP = {
     "flax_nnx_attention": "benchmark_attention.flax_nnx_attention_benchmark",
     "flax_linen_attention": ("benchmark_attention.flax_linen_attention_benchmark"),
     "keras_attention": "benchmark_attention.keras_attention_benchmark",
+    "tokamax_splash_attention": "benchmark_attention.tokamax_splash_attention_benchmark",
 }
 HBM_BENCHMARK_MAP = {
     "single_chip_hbm_copy": "benchmark_hbm.single_chip_hbm_copy",
@@ -181,7 +182,13 @@ def generate_benchmark_params_sweeping(
             if key.endswith("_range"):
                 key = key[:-6]  # Remove the last 6 characters (i.e., '_range')
 
-            if isinstance(value, dict):
+            if key.endswith("_list"):
+                key = key[:-5]  # Remove the last 6 characters (i.e., '_list')
+
+            if isinstance(value, list):
+                param_sets[key] = value
+
+            elif isinstance(value, dict):
                 # Extract the range and multiplier
                 start = value.get("start")
                 end = value.get("end")


### PR DESCRIPTION
Added a benchmark to evaluate the performance of the Tokamax Splash Attention implementation.

Modified generate_benchmark_params_sweeping() function in src/run_benchmark.py. The changes now allow a list of discrete values to be passed for any hyperparameter, in addition to ranges.