### PR TITLE
Rename functions which are related to HBM testing and add a simple yaml file for HBM microbenchmarks

### DIFF
--- a/Ironwood/configs/training/hbm.yaml
+++ b/Ironwood/configs/training/hbm.yaml
@@ -1,5 +1,5 @@
 benchmarks:
-- benchmark_name: "single_chip_hbm_copy"
+- benchmark_name: "single_device_hbm_copy"
   benchmark_sweep_params:
   - {num_elements_range: {start: 1048576, end: 4294967296, multiplier: 2}, dtype: "bfloat16", num_runs: 1}
   trace_dir: "../microbenchmarks/hbm"

--- a/Ironwood/src/benchmark_hbm.py
+++ b/Ironwood/src/benchmark_hbm.py
@@ -33,7 +33,7 @@ def get_metrics_helper(
     return metadata
 
 
-def single_chip_hbm_copy(
+def single_device_hbm_copy(
     num_elements: int,
     dtype: jnp.dtype,
     num_runs: int = 1,
@@ -66,10 +66,10 @@ def single_chip_hbm_copy(
     return {"time_ms_list": time_ms_list}
 
 
-def single_chip_hbm_copy_calculate_metrics(
+def single_device_hbm_copy_calculate_metrics(
     num_elements: int, dtype: jnp.dtype, time_ms_list: list
 ) -> Dict[str, Any]:
-    """Calculates the metrics for the single chip hbm copy benchmark."""
+    """Calculates the metrics for the single device hbm copy benchmark."""
     # Build dictionary of all the parameters in the function
     params = locals().items()
     metadata = get_metrics_helper(params)

--- a/Ironwood/src/benchmark_utils.py
+++ b/Ironwood/src/benchmark_utils.py
@@ -31,7 +31,7 @@ TARGET_TASK_NAME_COLLECTIVES_MAP = {
     "all_gather_ici_op": r"all-gather.[0-9]+",
     "psum_ici_op": r"all-reduce.[0-9]+",
     "ppermute_ici_op": r"collective-permute.[0-9]+",
-    "single_chip_hbm_copy": r"copy.[0-9]+",
+    "single_device_hbm_copy": r"copy.[0-9]+",
 }
 
 

--- a/Ironwood/src/run_benchmark.py
+++ b/Ironwood/src/run_benchmark.py
@@ -52,7 +52,7 @@ ATTENTION_BENCHMARK_MAP = {
     "tokamax_splash_attention": "benchmark_attention.tokamax_splash_attention_benchmark",
 }
 HBM_BENCHMARK_MAP = {
-    "single_chip_hbm_copy": "benchmark_hbm.single_chip_hbm_copy",
+    "single_device_hbm_copy": "benchmark_hbm.single_device_hbm_copy",
 }
 COMPUTE_BENCHMARK_MAP = {
     "gemm_simple": "benchmark_gemm.gemm_simple",


### PR DESCRIPTION
In the file `Ironwood/src/benchmark_hbm.py`, functions `single_chip_hbm_copy` and `single_chip_hbm_copy_calculate_metrics` are used to produce HBM microbenchmarks. However, since there are two devices on an Ironwood chip, using 'device' and 'chip' interchangeably will lead to user misunderstanding. Therefore, this PR renamed these two functions and the files which import them.

The detailed changes include:
- Rename functions and modify comments in `Ironwood/src/benchmark_hbm.py`.
- Modify the import path in  `Ironwood/src/run_benchmark.py` and `Ironwood/src/benchmark_utils.py`