### PR TITLE
Flush host-device benchmark output

### DIFF
--- a/Ironwood/src/benchmark_host_device.py
+++ b/Ironwood/src/benchmark_host_device.py
@@ -33,7 +33,8 @@ def benchmark_host_device(
     host_data = np.random.normal(size=(num_elements // column, column)).astype(np.float32)
     
     print(
-        f"Benchmarking Transfer with Data Size: {data_size_mib} MB for {num_runs} iterations"
+        f"Benchmarking Transfer with Data Size: {data_size_mib} MB for {num_runs} iterations",
+        flush=True
     )
 
     # Performance Lists
@@ -117,6 +118,10 @@ def benchmark_host_device_calculate_metrics(
             for ms in ms_list
         ]
         stats_bw = MetricsStatistics(bw_list, f"{name}_bw (GiB/s)")
+        print(
+            f"  {name}_bw (GiB/s) median: {stats_bw.statistics['p50']}, P95: {stats_bw.statistics['p95']}", 
+            flush=True
+        )
         metrics.update(stats_bw.serialize_statistics())
 
     add_metric("H2D", H2D_Bandwidth_ms)


### PR DESCRIPTION
### Problem

The benchmark often seems 'hanging' which is caused by stdout not flushed until the benchmark is completed.

### Solution

Flush the `print` when it's important execution point and wouldn't impact performance.