### PR TITLE
add GCS service account name to job yamls

### DIFF
--- a/Ironwood/guides/automation/tpu7x-2x2x1-collectives.yaml
+++ b/Ironwood/guides/automation/tpu7x-2x2x1-collectives.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     spec:
       subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
       restartPolicy: Never
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x

--- a/Ironwood/guides/automation/tpu7x-2x2x1-gemm.yaml
+++ b/Ironwood/guides/automation/tpu7x-2x2x1-gemm.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     spec:
       subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
       restartPolicy: Never
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x

--- a/Ironwood/guides/automation/tpu7x-2x2x1-hbm.yaml
+++ b/Ironwood/guides/automation/tpu7x-2x2x1-hbm.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     spec:
       subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
       restartPolicy: Never
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x

--- a/Ironwood/guides/automation/tpu7x-2x2x1-host_device.yaml
+++ b/Ironwood/guides/automation/tpu7x-2x2x1-host_device.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     spec:
       subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
       restartPolicy: Never
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x

--- a/Ironwood/guides/automation/tpu7x-2x2x2-collectives.yaml
+++ b/Ironwood/guides/automation/tpu7x-2x2x2-collectives.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     spec:
       subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
       restartPolicy: Never
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x

--- a/Ironwood/guides/automation/tpu7x-2x2x4-collectives.yaml
+++ b/Ironwood/guides/automation/tpu7x-2x2x4-collectives.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     spec:
       subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
       restartPolicy: Never
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x

--- a/Ironwood/guides/automation/tpu7x-2x4x4-collectives.yaml
+++ b/Ironwood/guides/automation/tpu7x-2x4x4-collectives.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     spec:
       subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
       restartPolicy: Never
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x

--- a/Ironwood/guides/automation/tpu7x-4x4x4-collectives.yaml
+++ b/Ironwood/guides/automation/tpu7x-4x4x4-collectives.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     spec:
       subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
       restartPolicy: Never
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x

--- a/Ironwood/guides/automation/tpu7x-4x4x8-collectives.yaml
+++ b/Ironwood/guides/automation/tpu7x-4x4x8-collectives.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     spec:
       subdomain: headless-svc-${JOB_NAME}
+      serviceAccountName: ${GCS_SA_NAME}
       restartPolicy: Never
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu7x


### PR DESCRIPTION
this PR does:
1. add GCS service account as env and update the automation script
2. append random str to the job name, this is for distributed collective jobs which will always have unique headless-svc service name.