### PR TITLE
Add --numactl_bind flag to H2D benchmark script

### DIFF
--- a/Ironwood/scripts/run_host_device_benchmark.sh
+++ b/Ironwood/scripts/run_host_device_benchmark.sh
@@ -11,7 +11,6 @@ usage() {
     echo "Usage: $0 [OPTIONS]"
     echo "Options:"
     echo "  --config <path>       Path to specific config file (optional)"
-    echo "  --numactl_bind        Run with numactl --cpunodebind=0 --membind=0"
     echo "  --interleaved         Run with numactl --interleave=all"
     echo "  --numactl_bind        Run with numactl --cpunodebind=0 --membind=0"
     echo "  --help                Show this help message"


### PR DESCRIPTION
This commit adds a flag to enable using `numactl  --cpunodebind=0 --membind=0 $CMD` to bind to the first NUMA node for CPU and memory. This minimizes unnecessary cross-NUMA transfers and produces more consistent benchmark results.