### PR TITLE
Remove 32768 data_size_mib from H2D YAML

### DIFF
--- a/Ironwood/configs/host_device/host_device.yaml
+++ b/Ironwood/configs/host_device/host_device.yaml
@@ -3,7 +3,7 @@ benchmarks:
   num_runs: 20
   benchmark_sweep_params:
   - {
-      data_size_mib_list: [1, 16, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+      data_size_mib_list: [1, 16, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]
     }
   csv_path: "../microbenchmarks/host_device"
   trace_dir: "../microbenchmarks/host_device/trace"


### PR DESCRIPTION
Remove the 32768 data_size_mib configuration in the host_device.yaml for the time being. This is currently breaking the automation.