### PR TITLE
update benchmark_attention not sweep at the runtime

### DIFF
--- a/Ironwood/configs/attention/attention.yaml
+++ b/Ironwood/configs/attention/attention.yaml
@@ -1,12 +1,7 @@
 benchmarks:
 - benchmark_name: "tokamax_splash_attention"
   benchmark_sweep_params:
-  - {batch_size: 1, q_seq_len: 4096, kv_seq_len: 4096, q_heads: 128, kv_heads: 8, qk_head_dim: 256, v_head_dim: 256, mode: ["fwd", "bwd"], causal: [true, false], num_samples: 3500, tune_pallas_only: true}
-  - {batch_size: 1, q_seq_len: 8192, kv_seq_len: 8192, q_heads: 128, kv_heads: 8, qk_head_dim: 256, v_head_dim: 256, mode: ["fwd", "bwd"], causal: [true, false], num_samples: 3500, tune_pallas_only: true}
-  - {batch_size: 1, q_seq_len: 16384, kv_seq_len: 16384, q_heads: 128, kv_heads: 8, qk_head_dim: 256, v_head_dim: 256, mode: ["fwd", "bwd"], causal: [true, false], num_samples: 3500, tune_pallas_only: true}
-  - {batch_size: 1, q_seq_len: 32768, kv_seq_len: 32768, q_heads: 128, kv_heads: 8, qk_head_dim: 256, v_head_dim: 256, mode: ["fwd", "bwd"], causal: [true, false], num_samples: 3500, tune_pallas_only: true}
-  - {batch_size: 1, q_seq_len: 65536, kv_seq_len: 65536, q_heads: 128, kv_heads: 8, qk_head_dim: 256, v_head_dim: 256, mode: ["fwd", "bwd"], causal: [true, false], num_samples: 3500, tune_pallas_only: true}
-  - {batch_size: 1, q_seq_len: 131072, kv_seq_len: 131072, q_heads: 128, kv_heads: 8, qk_head_dim: 256, v_head_dim: 256, mode: ["fwd", "bwd"], causal: [true, false], num_samples: 3500, tune_pallas_only: true}
+  - {batch_size: 1, q_seq_len: 4096, kv_seq_len: 4096, q_heads: 128, kv_heads: 128, qk_head_dim: 256, v_head_dim: 256, mode: ["fwd", "bwd"], causal: [true, false]}
   trace_dir: "../microbenchmarks/attention"
   csv_path: "../microbenchmarks/attention"
   xlml_metrics_dir: "../microbenchmarks/attention"

--- a/Ironwood/src/benchmark_attention.py
+++ b/Ironwood/src/benchmark_attention.py
@@ -6,26 +6,95 @@ import os
 
 # pylint: disable=g-importing-member,g-bad-import-order
 from functools import partial
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Literal, Optional, Tuple
 import dataclasses
 
 from benchmark_utils import timeit_from_trace, MetricsStatistics
 import jax
-import logging
+import jax.numpy as jnp
+
 from tokamax._src.ops.experimental.tpu.splash_attention import (
     splash_attention_kernel as splash,
 )
 from tokamax._src.ops.experimental.tpu.splash_attention import (
     splash_attention_mask as mask_lib,
 )
-import tune_jax
-tune_jax.tune_logger.setLevel(logging.ERROR)
 
 # pylint: disable=g-importing-member,g-bad-import-order
 
 os.environ["LIBTPU_INIT_ARGS"] = (
-    "--xla_tpu_dvfs_p_state=7"
+    "--xla_tpu_dvfs_p_state=7 --xla_tpu_scoped_vmem_limit_kib=65536"
 )
+
+SplashAttentionLookupKey = tuple[
+    int, # batch_size
+    int, # q_seq_len
+    int, # kv_seq_len
+    int, # q_heads
+    int, # kv_heads
+    int, # qk_head_dim
+    int, # v_head_dim
+    bool, # causal
+]
+
+SplashAttentionLookupValue = tuple[
+    int, # block_q
+    int, # block_kv
+    int, # block_kv_compute
+    int, # block_q_dkv
+    int, # block_kv_dkv
+    int, # block_kv_dkv_compute
+    splash.QKVLayout, # q_layout
+    splash.QKVLayout, # k_layout
+    splash.QKVLayout, # v_layout
+    bool, # use_experimental_scheduler
+]
+
+# Merge the tuned block size of optimal fwd and bwd
+# The optimal layout and use_experimental_scheduler may be different between fwd and bwd
+# Use the layout and use_experimental_scheduler optimized for fwd
+SPLASH_ATTENTION_HYPERPARAMS_LOOKUP_TABLE: Dict[
+    SplashAttentionLookupKey, SplashAttentionLookupValue
+] = {
+    (1, 4096, 4096, 128, 128, 256, 256, True): (
+        2048,
+        2048,
+        256,
+        2048,
+        2048,
+        512,
+        splash.QKVLayout.HEAD_DIM_MINOR,
+        splash.QKVLayout.SEQ_MINOR,
+        splash.QKVLayout.HEAD_DIM_MINOR,
+        True,
+    ),
+    (1, 4096, 4096, 128, 128, 256, 256, False): (
+        4096,
+        4096,
+        512,
+        4096,
+        2048,
+        512,
+        splash.QKVLayout.HEAD_DIM_MINOR,
+        splash.QKVLayout.SEQ_MINOR,
+        splash.QKVLayout.HEAD_DIM_MINOR,
+        True,
+    ),
+}
+
+DEFAULT_SPLASH_ATTENTION_HYPERPARAMS: SplashAttentionLookupValue = (
+    2048,
+    2048,
+    256,
+    2048,
+    2048,
+    256,
+    splash.QKVLayout.HEAD_DIM_MINOR,
+    splash.QKVLayout.SEQ_MINOR,
+    splash.QKVLayout.HEAD_DIM_MINOR,
+    True,
+)
+
 
 def generate_qkv_separate_dims(
     batch_size: int,
@@ -40,9 +109,9 @@ def generate_qkv_separate_dims(
     """Generates QKV with potentially different shapes for Q, K, and V."""
     key = jax.random.PRNGKey(seed)
     key_q, key_k, key_v = jax.random.split(key, 3)
-    q = jax.random.normal(key_q, (batch_size, q_heads, q_seq_len, qk_head_dim))
-    k = jax.random.normal(key_k, (batch_size, kv_heads, kv_seq_len, qk_head_dim))
-    v = jax.random.normal(key_v, (batch_size, kv_heads, kv_seq_len, v_head_dim))
+    q = jax.random.normal(key_q, (batch_size, q_heads, q_seq_len, qk_head_dim), dtype=jnp.bfloat16)
+    k = jax.random.normal(key_k, (batch_size, kv_heads, kv_seq_len, qk_head_dim), dtype=jnp.bfloat16)
+    v = jax.random.normal(key_v, (batch_size, kv_heads, kv_seq_len, v_head_dim), dtype=jnp.bfloat16)
     return q, k, v
 
 
@@ -106,28 +175,14 @@ def tokamax_splash_attention_benchmark(
     kv_heads: int,
     qk_head_dim: int,
     v_head_dim: int,
-    mode: str = "fwd",  # One of ('fwd', 'bwd', 'combined')
+    mode: Literal["fwd", "bwd"] = "fwd",
     causal: bool = True,
-    num_samples: int = 256,
-    tune_pallas_only: bool = True,
     num_runs: int = 10,
-    trace_dir: str = None,
+    trace_dir: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Benchmarks the Tokamax Splash attention kernel."""
     event_filter_regex = _pallas_call_hlo_pattern(mode, q_heads != kv_heads)
-
-    hyperparams_override = {}
-    if mode == "bwd":
-        # Don't tune fwd only hyperparams
-        hyperparams_override = dict(
-            block_q=min(512, q_seq_len),
-            block_kv=min(1024, kv_seq_len),
-            block_kv_compute=min(512, kv_seq_len),
-        )
-    elif mode == "combined":
-        mode = "bwd"
-
-    # Generate QKV.
+    # Generate QKV in shape [batch, head_num, seq_len, head_dim].
     q, k, v = generate_qkv_separate_dims(
         batch_size,
         q_seq_len,
@@ -138,12 +193,68 @@ def tokamax_splash_attention_benchmark(
         v_head_dim,
     )
 
+    key = (
+        batch_size,
+        q_seq_len,
+        kv_seq_len,
+        q_heads,
+        kv_heads,
+        qk_head_dim,
+        v_head_dim,
+        causal,
+    )
+    hyperparams: Optional[SplashAttentionLookupValue] = (
+        SPLASH_ATTENTION_HYPERPARAMS_LOOKUP_TABLE.get(key, None)
+    )
+    has_optimized = True
+    if hyperparams is None:
+        print(f"{key=} is not tuned")
+        has_optimized = False
+        hyperparams = DEFAULT_SPLASH_ATTENTION_HYPERPARAMS
+    
+    (
+        block_q,
+        block_kv,
+        block_kv_compute,
+        block_q_dkv,
+        block_kv_dkv,
+        block_kv_dkv_compute,
+        q_layout,
+        k_layout,
+        v_layout,
+        use_experimental_scheduler,
+    ) = hyperparams
+
+    # Pad q, kv to prevent the block size are not valid
+    if not has_optimized:
+        def _ceiling_div(a: int, b: int) -> int:
+            return (a + b - 1) // b
+
+
+        def _align_to(x: int, a: int) -> int:
+            return _ceiling_div(x, a) * a
+
+        def _pad_token(t: jax.Array, size) -> jax.Array:
+            # tensor is [batch_size, num_head, token, head_dim]
+            result = jnp.pad(t, ((0, 0), (0, 0), (0, size), (0, 0)), constant_values=0)
+            return result
+
+        q_len = q.shape[-2]
+        k_len = k.shape[-2]
+
+        # Pad q, k, v sequence, align to block sizes
+        q = _pad_token(q, _align_to(q_len, block_q) - q_len)
+        k = _pad_token(k, _align_to(k_len, block_kv) - k_len)
+        v = _pad_token(v, _align_to(k_len, block_kv) - k_len)
+
+    padded_q_len = q.shape[-2]
+    padded_kv_len = k.shape[-2]
     # Attention mask
-    mask = mask_lib.FullMask(_shape=(q_seq_len, kv_seq_len))
+    mask = mask_lib.FullMask(_shape=(padded_q_len, padded_kv_len))
     if causal:
         # Pick offset for causal masks for a "representative" slice of the causal
-        offset = v.shape[-2] - q.shape[-2]
-        mask = mask_lib.CausalMask(shape=(q_seq_len, kv_seq_len), offset=offset)
+        offset = padded_kv_len - padded_q_len
+        mask = mask_lib.CausalMask(shape=(padded_q_len, padded_kv_len), offset=offset)
 
     def attention_fn(
         q: jax.Array,
@@ -155,8 +266,6 @@ def tokamax_splash_attention_benchmark(
         block_q_dkv: int | None,
         block_kv_dkv: int | None,
         block_kv_dkv_compute: int | None,
-        block_q_dq: int | None,
-        block_kv_dq: int | None,
         q_layout: splash.QKVLayout,
         k_layout: splash.QKVLayout,
         v_layout: splash.QKVLayout,
@@ -165,6 +274,7 @@ def tokamax_splash_attention_benchmark(
         mqa: bool,
         use_experimental_scheduler: bool,
     ):
+        # dq kernel is not used
         config = splash.SplashConfig(
             block_q=block_q,
             block_kv=block_kv,
@@ -172,8 +282,8 @@ def tokamax_splash_attention_benchmark(
             block_q_dkv=block_q_dkv,
             block_kv_dkv=block_kv_dkv,
             block_kv_dkv_compute=block_kv_dkv_compute,
-            block_q_dq=block_q_dq,
-            block_kv_dq=block_kv_dq,
+            block_q_dq=None,
+            block_kv_dq=None,
             q_layout=q_layout,
             k_layout=k_layout,
             v_layout=v_layout,
@@ -190,38 +300,6 @@ def tokamax_splash_attention_benchmark(
         mqa=q_heads != kv_heads,  # Determine if it's Multi-Query Attention
     )
 
-    # Define the search space for tokamax splash attention hyperparameters.
-    tiles = [256, 512, 1024, 2048, 4096, 8192]
-    layouts = [splash.QKVLayout.HEAD_DIM_MINOR, splash.QKVLayout.SEQ_MINOR]
-    hyperparams = {
-        "block_q": tiles,
-        "block_kv": tiles,
-        "block_kv_compute": tiles,
-        "block_q_dkv": [None],
-        "block_kv_dkv": [None],
-        "block_kv_dkv_compute": [None],
-        "block_q_dq": [None],
-        "block_kv_dq": [None],
-        "q_layout": layouts,
-        "k_layout": layouts,
-        "v_layout": layouts,
-        "use_experimental_scheduler": [True, False],
-    }
-
-    if mode == "bwd":
-        # If mode is backward, enable tuning for dKV-related block sizes.
-        # These parameters are only used during the backward pass.
-        hyperparams["block_q_dkv"] = tiles
-        hyperparams["block_kv_dkv"] = tiles
-        hyperparams["block_kv_dkv_compute"] = tiles
-        hyperparams["block_q_dq"] = tiles
-        hyperparams["block_kv_dq"] = tiles
-
-    # Incorporate any potentially previously tuned hyperparameters
-    hyperparams = dict(hyperparams, **hyperparams_override)
-
-    # Prepare the attention function for tuning.
-    tune_jax.CONFIG.allow_fallback_timing = False
     splash_fn = jax.jit(
         attention_fn,
         static_argnames=(
@@ -231,8 +309,6 @@ def tokamax_splash_attention_benchmark(
             "block_q_dkv",
             "block_kv_dkv",
             "block_kv_dkv_compute",
-            "block_q_dq",
-            "block_kv_dq",
             "q_layout",
             "k_layout",
             "v_layout",
@@ -240,26 +316,31 @@ def tokamax_splash_attention_benchmark(
         ),
     )
 
-    # Tune the hyperparameters with tune_jax
-    tuned_splash = tune_jax.tune(
+    tuned_splash = partial(
         splash_fn,
-        hyperparams=hyperparams,
-        event_filter_regex=event_filter_regex if tune_pallas_only else None,
-        sample_num=num_samples,
+        block_q=block_q,
+        block_kv=block_kv,
+        block_kv_compute=block_kv_compute,
+        block_q_dkv=block_q_dkv,
+        block_kv_dkv=block_kv_dkv,
+        block_kv_dkv_compute=block_kv_dkv_compute,
+        q_layout=q_layout,
+        k_layout=k_layout,
+        v_layout=v_layout,
+        use_experimental_scheduler=use_experimental_scheduler,
     )
 
     # Run once
     output = tuned_splash(q, k, v)
     jax.block_until_ready(output)
 
-    
     print("-" * 50)
     print(
         f"batch_size={batch_size}, q_seq_len={q_seq_len}, kv_seq_len={kv_seq_len}, "
         f"q_heads={q_heads}, kv_heads={kv_heads}, qk_head_dim={qk_head_dim}, "
         f"v_head_dim={v_head_dim}, mode={mode}, causal={causal}"
     )
-    print(f"tuned_splash.optimal_hyperparams={tuned_splash.optimal_hyperparams}")
+    print(f"{hyperparams=}")
     print("-" * 50)
 
     # Run benchmark
@@ -275,7 +356,11 @@ def tokamax_splash_attention_benchmark(
             f"{event_filter_regex}_no_residuals.1",
         ]
     )
-    return {"time_ms_list": time_ms_list, "output": output}
+    return {
+        "time_ms_list": time_ms_list,
+        "output": output,
+        "has_optimized": has_optimized,
+    }
 
 
 def tokamax_splash_attention_benchmark_calculate_metrics(
@@ -289,9 +374,8 @@ def tokamax_splash_attention_benchmark_calculate_metrics(
     v_head_dim: int,
     mode: str,
     causal: bool,
-    num_samples: int,
-    tune_pallas_only: bool,
     time_ms_list: list[float],
+    has_optimized: bool,
     # pylint: disable=unused-argument
 ) -> Dict[str, Any]:
     """Gathers metrics for the tokamax splash attention benchmark."""


### PR DESCRIPTION
We add a tuned table instead of. run the sweeping at each microbenchmark. For the config not tuned yet, we just use
default block sizes and output with flag has_optimized=false.