### PR TITLE
fix: Fix metric keys for host-device benchmark

### DIFF
--- a/Ironwood/src/benchmark_host_device.py
+++ b/Ironwood/src/benchmark_host_device.py
@@ -96,8 +96,8 @@ def benchmark_host_device(
                 device_array.delete()
 
     return {
-        "H2D_Bandwidth_ms": h2d_perf,
-        "D2H_Bandwidth_ms": d2h_perf,
+        "h2d_bandwidth_ms": h2d_perf,
+        "d2h_bandwidth_ms": d2h_perf,
     }
 
 

--- a/Ironwood/src/benchmark_utils.py
+++ b/Ironwood/src/benchmark_utils.py
@@ -804,7 +804,14 @@ def upload_to_storage(trace_dir: str, local_file: str):
     if trace_dir.startswith("gs://"):  # Google Cloud Storage (GCS)
         try:
             subprocess.run(
-                ["gcloud", "storage", "cp", "--recursive", local_file, trace_dir],
+                [
+                    "gcloud",
+                    "storage",
+                    "cp",
+                    "--recursive",
+                    local_file,
+                    trace_dir,
+                ],
                 check=True,
                 capture_output=True,
             )

--- a/src/benchmark_utils.py
+++ b/src/benchmark_utils.py
@@ -243,7 +243,14 @@ def upload_to_storage(trace_dir: str, local_file: str):
     if trace_dir.startswith("gs://"):  # Google Cloud Storage (GCS)
         try:
             subprocess.run(
-                ["gcloud", "storage", "cp", "--recursive", local_file, trace_dir],
+                [
+                    "gcloud",
+                    "storage",
+                    "cp",
+                    "--recursive",
+                    local_file,
+                    trace_dir,
+                ],
                 check=True,
                 capture_output=True,
             )


### PR DESCRIPTION

### Summary

Fixes a runtime `TypeError` in the host-device benchmark where metric arguments failed to unpack correctly.

The fix corrects an argument name mismatch between the benchmark function and the downstream metrics calculator in `benchmark_host_device.py`, standardizing the dictionary keys to lowercase (`h2d_bandwidth_ms` and `d2h_bandwidth_ms`).

### Testing

Verified by running the host-device microbenchmark locally on a TPU VM

```
python Ironwood/src/run_benchmark.py --config="Ironwood/configs/host_device/host_device.yaml"
```