### PR TITLE
Add sample variance and increase runs for h2dd2h benchmark

### DIFF
--- a/Ironwood/configs/host_device/comprehensive_experiments.yaml
+++ b/Ironwood/configs/host_device/comprehensive_experiments.yaml
@@ -1,6 +1,6 @@
 benchmarks:
 - benchmark_name: host_device
-  num_runs: 20
+  num_runs: 100
   benchmark_sweep_params:
   - transfer_type_list: ["pinned_memory", "simple", "pipelined"]
     num_devices_list: [1, 2, 8]

--- a/Ironwood/src/benchmark_host_device.py
+++ b/Ironwood/src/benchmark_host_device.py
@@ -291,6 +291,20 @@ def benchmark_host_device_calculate_metrics(
         )
         metrics.update(stats_bw.serialize_statistics())
 
+        if len(bw_list) > 1:
+            bw_array = np.array(bw_list)
+            sample_variance = np.var(bw_array, ddof=1)
+
+            metrics[f"{name}_bw (GiB/s)_sample_variance"] = sample_variance
+
+            print(
+                f"  {name}_bw (GiB/s) Sample Variance: {sample_variance:.4e}", 
+                flush=True
+            )
+        elif len(bw_list) == 1:
+            print(f"  {name}_bw (GiB/s): Only one sample, variance cannot be calculated.", flush=True)
+            metrics[f"{name}_bw_variance_GiBs"] = 0.0
+
     add_metric("H2D", H2D_Bandwidth_ms)
     add_metric("D2H", D2H_Bandwidth_ms)
 

--- a/Ironwood/src/benchmark_host_device.py
+++ b/Ironwood/src/benchmark_host_device.py
@@ -295,7 +295,7 @@ def benchmark_host_device_calculate_metrics(
             bw_array = np.array(bw_list)
             sample_variance = np.var(bw_array, ddof=1)
 
-            metrics[f"{name}_bw (GiB/s)_sample_variance"] = sample_variance
+            metrics[f"{name}_bw (GiB/s)_variance"] = sample_variance
 
             print(
                 f"  {name}_bw (GiB/s) Sample Variance: {sample_variance:.4e}", 

--- a/Ironwood/src/benchmark_host_device.py
+++ b/Ironwood/src/benchmark_host_device.py
@@ -291,19 +291,17 @@ def benchmark_host_device_calculate_metrics(
         )
         metrics.update(stats_bw.serialize_statistics())
 
-        if len(bw_list) > 1:
-            bw_array = np.array(bw_list)
-            sample_variance = np.var(bw_array, ddof=1)
+        bw_array = np.array(bw_list)
+        sample_variance = np.var(bw_array, ddof=1)
+        if np.isnan(sample_variance):
+            sample_variance = 0.0
 
-            metrics[f"{name}_bw (GiB/s)_variance"] = sample_variance
+        metrics[f"{name}_bw (GiB/s)_variance"] = sample_variance
 
-            print(
-                f"  {name}_bw (GiB/s) Sample Variance: {sample_variance:.4e}", 
-                flush=True
-            )
-        elif len(bw_list) == 1:
-            print(f"  {name}_bw (GiB/s): Only one sample, variance cannot be calculated.", flush=True)
-            metrics[f"{name}_bw_variance_GiBs"] = 0.0
+        print(
+            f"  {name}_bw (GiB/s) Sample Variance: {sample_variance:.4e}", 
+            flush=True
+        )
 
     add_metric("H2D", H2D_Bandwidth_ms)
     add_metric("D2H", D2H_Bandwidth_ms)


### PR DESCRIPTION
### What this PR does:
This PR improves the analysis of the Host-to-Device (H2D) and Device-to-Host (D2H) microbenchmark workload (`h2dd2h`). Specifically, it:
-   Introduces a calculation for the **sample variance** of the h2dd2h workload results.
-   Increases the number of runs for the h2dd2h benchmark from 20 to 100.

### Why these changes are needed:
-   **Sample Variance:** The `h2dd2h` workload has shown significant run-to-run variability. Adding sample variance as a metric provides deeper insight into the spread and consistency of the performance measurements, which is crucial for understanding the workload's behavior.
-   **Increased Runs:** The original 20 runs were found to be insufficient to accurately characterize the performance distribution of this workload. Increasing `num_runs` to 100 provides a more statistically robust dataset, allowing for better analysis and more reliable conclusions about the workload's performance.

### How these changes were implemented:
-   The code to calculate sample variance has been added within the `Ironwood/src/benchmark_host_device.py`.
-   The configuration value for `num_runs` was updated from 20 to 100 in the `Ironwood/configs/host_device/comprehensive_experiments.yaml`.

### How this was tested:
-   The `h2dd2h` benchmark was run with the updated configuration.
-   The output was verified to ensure the new sample variance metric is correctly computed and displayed.
-   Confirmed that the benchmark now executes 100 runs as expected.
- .