### PR TITLE
Modified comprehensive_8dev_experiments.yaml from 20 num runs to 100

### DIFF
--- a/Ironwood/configs/host_device/comprehensive_8dev_experiments.yaml
+++ b/Ironwood/configs/host_device/comprehensive_8dev_experiments.yaml
@@ -1,6 +1,6 @@
 benchmarks:
 - benchmark_name: host_device
-  num_runs: 20
+  num_runs: 100
   benchmark_sweep_params:
   - transfer_type_list: ["pinned_memory", "simple", "pipelined"]
     num_devices_list: [8]


### PR DESCRIPTION
### What this PR does:

This PR updates the microbenchmark workload configuration for 8-device Host to Device and Device to Host (`h2dd2h`). Specifically, it:

* Increases the number of runs for the benchmark from 20 to 100.

### Why these changes are needed:

* **Increased Runs:** The original 20 runs were insufficient to accurately characterize the performance distribution of this workload due to inherent run-to-run variability. Increasing `num_runs` to 100 provides a larger, more statistically robust dataset, ensuring more reliable and repeatable performance insights.

### How these changes were implemented:

* The configuration value for `num_runs` was updated from 20 to 100 in `Ironwood/configs/host_device/comprehensive_8dev_experiments.yaml`.

### How this was tested:

* Local verification to ensure the benchmark accepts the updated configuration and successfully executes for 100 runs.