### PR TITLE
fix: support run_on_local_node in gemm_throttling

### DIFF
--- a/Ironwood/src/benchmark_gemm_throttling.py
+++ b/Ironwood/src/benchmark_gemm_throttling.py
@@ -46,6 +46,7 @@ def gemm_throttling(
     dtype: jnp.dtype = jax.numpy.float8_e4m3fn,
     gap_strategy: str = "data_gen_every_iter_block_every_iter",
     trace_dir: str = None,
+    run_on_local_node: bool = False,
 ) -> Dict[str, Any]:
     """Benchmarks the OUT<M, N>:BF16 = IN0<M, K>:FP8 x IN1<N, K>:FP8.
 
@@ -59,7 +60,7 @@ def gemm_throttling(
             )
             return acc.astype(jnp.bfloat16)
 
-    mesh = create_mesh(SHARDING_STRATEGY)
+    mesh = create_mesh(SHARDING_STRATEGY, local_mesh=run_on_local_node)
     lhs_sharding = get_lhs_named_shading(mesh, SHARDING_STRATEGY)
     rhs_sharding = get_rhs_named_shading(mesh, SHARDING_STRATEGY)
     out_sharding = get_out_sharding(SHARDING_STRATEGY)
@@ -120,12 +121,16 @@ def gemm_throttling_calculate_metrics(
     gap_strategy: str,
     dtype: jnp.dtype,
     time_ms_list: list[float],
+    run_on_local_node: bool = False,
 ) -> Dict[str, Any]:
     # pylint: disable=unused-argument
     # Calculate FLOPs
     total_flops = 2 * m * k * n  # Total floating-point operations
+    device_count = (
+        jax.local_device_count() if run_on_local_node else jax.device_count()
+    )
     total_flops, total_flops_all_devices = handle_based_on_sharding(
-        total_flops, SHARDING_STRATEGY
+        total_flops, SHARDING_STRATEGY, device_count=device_count
     )
     return unified_flops_metrics(
         m,


### PR DESCRIPTION
### Summary
Support configurable mesh locality (`run_on_local_node`) in `gemm_throttling` to allow running GEMM thermal soak microbenchmarks on single host devices across multi-node clusters.

### Rationale & Context
Following the design in [#125](https://github.com/AI-Hypercomputer/accelerator-microbenchmarks/pull/125), `run_on_local_node` allows running microbenchmarks per single host (`jax.local_devices()`) rather than over the entire global cluster slice (`jax.devices()`).

### Changes Included
1. **`gemm_throttling()`:** Added `run_on_local_node: bool = False` parameter and passed `local_mesh=run_on_local_node` to `create_mesh()`.
2. **`gemm_throttling_calculate_metrics()`:** Added `run_on_local_node: bool = False` parameter and set `device_count = jax.local_device_count() if run_on_local_node else jax.device_count()` when calling `handle_based_on_sharding()`. This prevents inflated total FLOPs and throughput metrics in multi-node environments.