### PR TITLE
fix: default gemm_throttling to local device mesh for single-host execution

### DIFF
--- a/Ironwood/src/benchmark_gemm_throttling.py
+++ b/Ironwood/src/benchmark_gemm_throttling.py
@@ -59,7 +59,7 @@ def gemm_throttling(
             )
             return acc.astype(jnp.bfloat16)
 
-    mesh = create_mesh(SHARDING_STRATEGY)
+    mesh = create_mesh(SHARDING_STRATEGY, local_mesh=True)
     lhs_sharding = get_lhs_named_shading(mesh, SHARDING_STRATEGY)
     rhs_sharding = get_rhs_named_shading(mesh, SHARDING_STRATEGY)
     out_sharding = get_out_sharding(SHARDING_STRATEGY)
@@ -124,8 +124,9 @@ def gemm_throttling_calculate_metrics(
     # pylint: disable=unused-argument
     # Calculate FLOPs
     total_flops = 2 * m * k * n  # Total floating-point operations
+    device_count = jax.local_device_count()
     total_flops, total_flops_all_devices = handle_based_on_sharding(
-        total_flops, SHARDING_STRATEGY
+        total_flops, SHARDING_STRATEGY, device_count=device_count
     )
     return unified_flops_metrics(
         m,


### PR DESCRIPTION
### Summary
Default `gemm_throttling` to use a local device mesh (`local_mesh=True`) and `jax.local_device_count()` out of the box, eliminating the need to pass `run_on_local_node: True` in YAML configurations.

### Rationale
`gemm_throttling` is designed to measure sustained thermal soak on single-host accelerators using un-sharded GEMM computations (`ShardingStrategy.NO_SHARDING`).

When executed on multi-node TPU clusters, `create_mesh` previously defaulted to `local_mesh=False` (`jax.devices()`), attempting to allocate un-sharded 16k float32 GEMM temporaries across all global TPU devices in the slice. On multi-node clusters (e.g. 64 nodes / 256 chips), this resulted in a **64.50 GB HBM memory requirement**, exceeding the 31.25 GB usable HBM capacity per chip and causing a `RESOURCE_EXHAUSTED` OOM crash.

Setting `local_mesh=True` directly in `gemm_throttling` ensures it defaults to single-host local execution (`jax.local_devices()`), using ~4 GB HBM and running seamlessly across multi-node cluster deployments without requiring explicit `run_on_local_node: True` flags in external YAML configs.